### PR TITLE
Fix stock display by mapping API fields

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,26 @@ async function fetchStocks(): Promise<Stock[]> {
   try {
     const res = await fetch('https://brapi.dev/api/quote/list?limit=50&fundamental=true')
     const json = await res.json()
-    return json.stocks || json.results || []
+    const items = (json.stocks || json.results || []) as Array<Record<string, unknown>>
+    const toNumber = (v: unknown) => (typeof v === 'number' ? v : undefined)
+    return items.map((item) => {
+      const fundamental = (item.fundamental as Record<string, unknown>) || {}
+      return {
+        symbol: typeof item.symbol === 'string' ? item.symbol : (typeof item.stock === 'string' ? item.stock : ''),
+        regularMarketPrice: toNumber(item.regularMarketPrice) ?? toNumber(item.close),
+        priceEarnings: toNumber(item.priceEarnings) ?? toNumber(fundamental.priceEarnings),
+        priceBookValue: toNumber(item.priceBookValue) ?? toNumber(fundamental.priceBookValue),
+        dividendYield: toNumber(item.dividendYield) ?? toNumber(fundamental.dividendYield),
+        roe: toNumber(item.roe) ?? toNumber(fundamental.roe),
+        grossDebt: toNumber(item.grossDebt) ?? toNumber(fundamental.grossDebt),
+        equity: toNumber(item.equity) ?? toNumber(fundamental.equity),
+        earningsPerShare: toNumber(item.earningsPerShare) ?? toNumber(fundamental.earningsPerShare),
+        bookValuePerShare: toNumber(item.bookValuePerShare) ?? toNumber(fundamental.bookValuePerShare),
+        profitGrowth5y: toNumber(item.profitGrowth5y) ?? toNumber(fundamental.profitGrowth5y),
+        ebitda: toNumber(item.ebitda) ?? toNumber(fundamental.ebitda),
+        marketCap: toNumber(item.marketCap) ?? toNumber(fundamental.marketCap),
+      }
+    })
   } catch {
     return []
   }

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -40,11 +40,11 @@ export function evEbitda(s: Stock) {
 }
 
 export function passesDefaultFilters(s: Stock) {
-  if ((s.priceEarnings ?? 0) <= 0) return false;
-  if ((s.priceBookValue ?? 0) > 1) return false;
-  if ((s.roe ?? 0) < 15) return false;
-  if (debtEquity(s) >= 1) return false;
-  if (pegRatio(s) > 1) return false;
-  if (evEbitda(s) > 10) return false;
+  if (s.priceEarnings !== undefined && s.priceEarnings <= 0) return false;
+  if (s.priceBookValue !== undefined && s.priceBookValue > 1) return false;
+  if (s.roe !== undefined && s.roe < 15) return false;
+  if (s.grossDebt !== undefined && s.equity !== undefined && debtEquity(s) >= 1) return false;
+  if (s.profitGrowth5y !== undefined && pegRatio(s) > 1) return false;
+  if (s.marketCap !== undefined && s.ebitda !== undefined && evEbitda(s) > 10) return false;
   return true;
 }


### PR DESCRIPTION
## Summary
- map API result keys to internal Stock type
- apply filters only when metric data is available

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68af0ee46a3c8328bf91db952a953682